### PR TITLE
Improvements of Table to Relation conversion

### DIFF
--- a/orangecontrib/datafusion/table.py
+++ b/orangecontrib/datafusion/table.py
@@ -84,3 +84,7 @@ class Relation(Table):
         :return: number of rows in relation
         """
         return len(self.relation.data)
+
+    @classmethod
+    def from_table(cls, domain, source, row_indices=...):
+        return Table.from_table(domain, source, row_indices)

--- a/orangecontrib/datafusion/table.py
+++ b/orangecontrib/datafusion/table.py
@@ -58,7 +58,6 @@ class Relation(Table):
         metas = np.array(metas_data, dtype='object')
         return metas_vars, metas
 
-
     @property
     def col_type(self):
         return self.relation.col_type

--- a/orangecontrib/datafusion/table.py
+++ b/orangecontrib/datafusion/table.py
@@ -44,6 +44,9 @@ class Relation(Table):
             for md, v in zip(metas_data, relation.row_metadata):
                 for k in metadata_names:
                     md.append(v.get(k, np.nan))
+        elif relation.row_names is not None:
+            metas = [relation.row_type.name]
+            metas_data = [[name] for name in relation.row_names]
 
         def create_var(x):
             if isinstance(x, Variable):

--- a/orangecontrib/datafusion/widgets/owtabletorelation.py
+++ b/orangecontrib/datafusion/widgets/owtabletorelation.py
@@ -144,16 +144,26 @@ class OWTableToRelation(OWWidget):
 
     def commit(self):
         if self.data:
+            domain = self.data.domain
+            metadata_cols = list(domain.class_vars) + list(domain.metas)
+            if self.row_names_attribute:
+                metadata_cols.remove(domain[self.row_names_attribute])
+            metadata = [{var: var.to_val(value) for var, value in zip(metadata_cols, values.list)}
+                        for values in self.data[:, metadata_cols]]
+
             if self.transpose:
                 relation = fusion.Relation(
-                    self.data.X, name=self.relation_name,
+                    self.data.X.T, name=self.relation_name,
                     row_type=fusion.ObjectType(self.col_type or 'Unknown'), row_names=self.col_names,
-                    col_type=fusion.ObjectType(self.row_type or 'Unknown'), col_names=self.row_names)
+                    col_type=fusion.ObjectType(self.row_type or 'Unknown'), col_names=self.row_names,
+                    col_metadata=metadata)
             else:
                 relation = fusion.Relation(
                     self.data.X, name=self.relation_name,
                     row_type=fusion.ObjectType(self.row_type or 'Unknown'), row_names=self.row_names,
-                    col_type=fusion.ObjectType(self.col_type or 'Unknown'), col_names=self.col_names)
+                    row_metadata=metadata,
+                    col_type=fusion.ObjectType(self.col_type or 'Unknown'), col_names=self.col_names,
+                )
             self.send(Output.RELATION, Relation(relation))
 
 

--- a/orangecontrib/datafusion/widgets/owtabletorelation.py
+++ b/orangecontrib/datafusion/widgets/owtabletorelation.py
@@ -27,7 +27,7 @@ class OWTableToRelation(OWWidget):
     transpose = ContextSetting(False)
 
     row_type = ContextSetting("")
-    row_names_attribute = ContextSetting("")
+    selected_meta = ContextSetting(0)
     row_names = None
 
     col_type = ContextSetting("")
@@ -55,8 +55,7 @@ class OWTableToRelation(OWWidget):
 
         row = gui.widgetBox(self.controlArea, "Row")
         gui.lineEdit(row, self, "row_type", "Object Type", callbackOnType=True, callback=self.apply)
-        self.row_names_combo = gui.comboBox(row, self, "row_names_attribute", label="Object Names",
-                                            sendSelectedValue=True, emptyString="(None)",
+        self.row_names_combo = gui.comboBox(row, self, "selected_meta", label="Object Names",
                                             callback=self.update_row_names)
 
         gui.rubber(self.controlArea)
@@ -101,22 +100,23 @@ class OWTableToRelation(OWWidget):
 
         if candidates:
             self.row_type = candidates[0].name
-            self.row_names_attribute = candidates[0]
+            self.selected_meta = 1
         else:
             self.row_type = ""
-            self.row_names_attribute = ""
+            self.selected_meta = 0
             self.row_names = None
 
         self.row_names_combo.clear()
         self.row_names_combo.addItem('(None)')
         for var in candidates:
             self.row_names_combo.addItem(self.icons[var], var.name)
+        self.row_names_combo.setCurrentIndex(self.selected_meta)
 
     def update_row_names(self):
-        if not self.row_names_attribute:
-            self.row_names = None
+        if self.selected_meta:
+            self.row_names = list(self.data[:, -self.selected_meta].metas.flatten())
         else:
-            self.row_names = list(self.data[:, self.row_names_attribute].metas.flatten())
+            self.row_names = None
 
         if self.model:
             self.model.headerDataChanged.emit(

--- a/orangecontrib/datafusion/widgets/owtabletorelation.py
+++ b/orangecontrib/datafusion/widgets/owtabletorelation.py
@@ -48,7 +48,7 @@ class OWTableToRelation(OWWidget):
     def populate_control_area(self):
         rel = gui.widgetBox(self.controlArea, "Relation")
         gui.lineEdit(rel, self, "relation_name", "Name", callbackOnType=True, callback=self.apply)
-        gui.checkBox(rel, self, "transpose", "Transpose")
+        gui.checkBox(rel, self, "transpose", "Transpose", callback=self.apply)
 
         col = gui.widgetBox(self.controlArea, "Column")
         gui.lineEdit(col, self, "col_type", "Object Type", callbackOnType=True, callback=self.apply)

--- a/orangecontrib/datafusion/widgets/owtabletorelation.py
+++ b/orangecontrib/datafusion/widgets/owtabletorelation.py
@@ -146,8 +146,6 @@ class OWTableToRelation(OWWidget):
         if self.data:
             domain = self.data.domain
             metadata_cols = list(domain.class_vars) + list(domain.metas)
-            if self.row_names_attribute:
-                metadata_cols.remove(domain[self.row_names_attribute])
             metadata = [{var: var.to_val(value) for var, value in zip(metadata_cols, values.list)}
                         for values in self.data[:, metadata_cols]]
 

--- a/orangecontrib/datafusion/widgets/owtabletorelation.py
+++ b/orangecontrib/datafusion/widgets/owtabletorelation.py
@@ -1,4 +1,4 @@
-from PyQt4.QtGui import QTableView, QSizePolicy, QHeaderView, QGridLayout, QWidget
+from PyQt4.QtGui import QTableView, QGridLayout, QWidget
 from PyQt4.QtCore import Qt, QSize
 from Orange.data import Table, Domain
 from Orange.widgets.settings import Setting, ContextSetting, PerfectDomainContextHandler
@@ -38,23 +38,31 @@ class OWTableToRelation(OWWidget):
     def __init__(self):
         super().__init__()
 
+        self.model = None
+        self.view = None
+        self.row_names_combo = None
+        self.icons = gui.attributeIconDict
+        self.populate_control_area()
+        self.populate_main_area()
+
+    def populate_control_area(self):
         rel = gui.widgetBox(self.controlArea, "Relation")
-        gui.lineEdit(rel, self, "relation_name", "Name", callbackOnType=True, callback=self.commit)
+        gui.lineEdit(rel, self, "relation_name", "Name", callbackOnType=True, callback=self.apply)
         gui.checkBox(rel, self, "transpose", "Transpose")
 
         col = gui.widgetBox(self.controlArea, "Column")
-        gui.lineEdit(col, self, "col_type", "Object Type", callbackOnType=True, callback=self.commit)
+        gui.lineEdit(col, self, "col_type", "Object Type", callbackOnType=True, callback=self.apply)
 
         row = gui.widgetBox(self.controlArea, "Row")
-        gui.lineEdit(row, self, "row_type", "Object Type", callbackOnType=True, callback=self.commit)
+        gui.lineEdit(row, self, "row_type", "Object Type", callbackOnType=True, callback=self.apply)
         self.row_names_combo = gui.comboBox(row, self, "row_names_attribute", label="Object Names",
                                             sendSelectedValue=True, emptyString="(None)",
                                             callback=self.update_row_names)
 
         gui.rubber(self.controlArea)
         gui.auto_commit(self.controlArea, self, "auto_commit", "Send")
-        self.icons = gui.attributeIconDict
 
+    def populate_main_area(self):
         grid = QWidget()
         grid.setLayout(QGridLayout(grid))
         self.mainArea.layout().addWidget(grid)
@@ -130,6 +138,9 @@ class OWTableToRelation(OWWidget):
         preview_data = Table(domain, self.data)
         self.model = MyTableModel(preview_data)
         self.view.setModel(self.model)
+
+    def apply(self):
+        self.commit()
 
     def commit(self):
         if self.data:


### PR DESCRIPTION
Move gui building to separate methods.

Use apply as callbacks to respect auto_commit option.

Pass all class_vars and metas in relation metadata.
