### PR TITLE
Revert "Improvements of Table to Relation conversion"

### DIFF
--- a/orangecontrib/datafusion/table.py
+++ b/orangecontrib/datafusion/table.py
@@ -1,4 +1,4 @@
-from Orange.data import Table, Domain, ContinuousVariable, StringVariable, Variable
+from Orange.data import Table, Domain, ContinuousVariable, StringVariable
 
 import numpy as np
 
@@ -18,45 +18,24 @@ class Relation(Table):
         relation: An instance of `skfusion.fusion.Relation`
         """
         self.relation = relation
-        meta_vars, self.metas = self._create_metas(relation)
-        self._Y = self.W = np.zeros((len(relation.data), 0))
+
+        empty = self._Y = self.W = np.zeros((len(relation.data), 0))
+        if relation.row_names is not None:
+            self.metas = np.array([str(x) for x in relation.row_names],
+                                  dtype='object')[:, None]
+            metas_vars = [StringVariable(str(relation.row_type))]
+        else:
+            self.metas = empty
+            metas_vars = []
 
         if relation.col_names is not None:
-            attr_names = relation.col_names
+            var_names = relation.col_names
         else:
-            attr_names = range(relation.data.shape[1])
+            var_names = range(relation.data.shape[1])
         self.domain = Domain([ContinuousVariable(name)
-                              for name in map(str, attr_names)],
-                             metas=meta_vars)
+                              for name in map(str, var_names)],
+                             metas=metas_vars)
         Table._init_ids(self)
-
-    @staticmethod
-    def _create_metas(relation):
-        metas = []
-        metas_data = [[] for x in relation.data]
-        if relation.row_metadata is not None:
-            metadata_names = set()
-            for md in relation.row_metadata:
-                metadata_names.update(md.keys())
-            metadata_names = sorted(metadata_names, key=str)
-
-            metas.extend(metadata_names)
-            for md, v in zip(metas_data, relation.row_metadata):
-                for k in metadata_names:
-                    md.append(v.get(k, np.nan))
-        elif relation.row_names is not None:
-            metas = [relation.row_type.name]
-            metas_data = [[name] for name in relation.row_names]
-
-        def create_var(x):
-            if isinstance(x, Variable):
-                return x
-            else:
-                return StringVariable(str(x))
-
-        metas_vars = [create_var(x) for x in metas]
-        metas = np.array(metas_data, dtype='object')
-        return metas_vars, metas
 
     @property
     def col_type(self):
@@ -85,7 +64,3 @@ class Relation(Table):
         :return: number of rows in relation
         """
         return len(self.relation.data)
-
-    @classmethod
-    def from_table(cls, domain, source, row_indices=...):
-        return Table.from_table(domain, source, row_indices)

--- a/orangecontrib/datafusion/widgets/owtabletorelation.py
+++ b/orangecontrib/datafusion/widgets/owtabletorelation.py
@@ -1,4 +1,4 @@
-from PyQt4.QtGui import QTableView, QGridLayout, QWidget
+from PyQt4.QtGui import QTableView, QSizePolicy, QHeaderView, QGridLayout, QWidget
 from PyQt4.QtCore import Qt, QSize
 from Orange.data import Table, Domain
 from Orange.widgets.settings import Setting, ContextSetting, PerfectDomainContextHandler
@@ -28,7 +28,7 @@ class OWTableToRelation(OWWidget):
     transpose = ContextSetting(False)
 
     row_type = ContextSetting("")
-    selected_meta = ContextSetting(0)
+    row_names_attribute = ContextSetting("")
     row_names = None
 
     col_type = ContextSetting("")
@@ -39,30 +39,23 @@ class OWTableToRelation(OWWidget):
     def __init__(self):
         super().__init__()
 
-        self.model = None
-        self.view = None
-        self.row_names_combo = None
-        self.icons = gui.attributeIconDict
-        self.populate_control_area()
-        self.populate_main_area()
-
-    def populate_control_area(self):
         rel = gui.widgetBox(self.controlArea, "Relation")
-        gui.lineEdit(rel, self, "relation_name", "Name", callbackOnType=True, callback=self.apply)
-        gui.checkBox(rel, self, "transpose", "Transpose", callback=self.apply)
+        gui.lineEdit(rel, self, "relation_name", "Name", callbackOnType=True, callback=self.commit)
+        gui.checkBox(rel, self, "transpose", "Transpose")
 
         col = gui.widgetBox(self.controlArea, "Column")
-        gui.lineEdit(col, self, "col_type", "Object Type", callbackOnType=True, callback=self.apply)
+        gui.lineEdit(col, self, "col_type", "Object Type", callbackOnType=True, callback=self.commit)
 
         row = gui.widgetBox(self.controlArea, "Row")
-        gui.lineEdit(row, self, "row_type", "Object Type", callbackOnType=True, callback=self.apply)
-        self.row_names_combo = gui.comboBox(row, self, "selected_meta", label="Object Names",
+        gui.lineEdit(row, self, "row_type", "Object Type", callbackOnType=True, callback=self.commit)
+        self.row_names_combo = gui.comboBox(row, self, "row_names_attribute", label="Object Names",
+                                            sendSelectedValue=True, emptyString="(None)",
                                             callback=self.update_row_names)
 
         gui.rubber(self.controlArea)
         gui.auto_commit(self.controlArea, self, "auto_commit", "Send")
+        self.icons = gui.attributeIconDict
 
-    def populate_main_area(self):
         grid = QWidget()
         grid.setLayout(QGridLayout(grid))
         self.mainArea.layout().addWidget(grid)
@@ -101,23 +94,22 @@ class OWTableToRelation(OWWidget):
 
         if candidates:
             self.row_type = candidates[0].name
-            self.selected_meta = 1
+            self.row_names_attribute = candidates[0]
         else:
             self.row_type = ""
-            self.selected_meta = 0
+            self.row_names_attribute = ""
             self.row_names = None
 
         self.row_names_combo.clear()
         self.row_names_combo.addItem('(None)')
         for var in candidates:
             self.row_names_combo.addItem(self.icons[var], var.name)
-        self.row_names_combo.setCurrentIndex(self.selected_meta)
 
     def update_row_names(self):
-        if self.selected_meta:
-            self.row_names = list(self.data[:, -self.selected_meta].metas.flatten())
-        else:
+        if not self.row_names_attribute:
             self.row_names = None
+        else:
+            self.row_names = list(self.data[:, self.row_names_attribute].metas.flatten())
 
         if self.model:
             self.model.headerDataChanged.emit(
@@ -140,29 +132,18 @@ class OWTableToRelation(OWWidget):
         self.model = MyTableModel(preview_data)
         self.view.setModel(self.model)
 
-    def apply(self):
-        self.commit()
-
     def commit(self):
         if self.data:
-            domain = self.data.domain
-            metadata_cols = list(domain.class_vars) + list(domain.metas)
-            metadata = [{var: var.to_val(value) for var, value in zip(metadata_cols, values.list)}
-                        for values in self.data[:, metadata_cols]]
-
             if self.transpose:
                 relation = fusion.Relation(
-                    self.data.X.T, name=self.relation_name,
+                    self.data.X, name=self.relation_name,
                     row_type=fusion.ObjectType(self.col_type or 'Unknown'), row_names=self.col_names,
-                    col_type=fusion.ObjectType(self.row_type or 'Unknown'), col_names=self.row_names,
-                    col_metadata=metadata)
+                    col_type=fusion.ObjectType(self.row_type or 'Unknown'), col_names=self.row_names)
             else:
                 relation = fusion.Relation(
                     self.data.X, name=self.relation_name,
                     row_type=fusion.ObjectType(self.row_type or 'Unknown'), row_names=self.row_names,
-                    row_metadata=metadata,
-                    col_type=fusion.ObjectType(self.col_type or 'Unknown'), col_names=self.col_names,
-                )
+                    col_type=fusion.ObjectType(self.col_type or 'Unknown'), col_names=self.col_names)
             self.send(Output.RELATION, Relation(relation))
 
 


### PR DESCRIPTION
Connect File->Table to Relation. Then remove the connection.

---

AttributeError                                Traceback (most recent call last):
  File "/Users/blaz/dev/orange3/Orange/canvas/scheme/widgetsscheme.py", line 661, in process_signals_for_widget
    handler(*args)
  File "/Users/blaz/dev/orange3-data-fusion/orangecontrib/datafusion/widgets/owtabletorelation.py", line 94, in set_data
    self.update_preview()
  File "/Users/blaz/dev/orange3-data-fusion/orangecontrib/datafusion/widgets/owtabletorelation.py", line 138, in update_preview
    domain = Domain(self.data.domain.attributes)
AttributeError: 'NoneType' object has no attribute 'domain'
