### PR TITLE
movielens: invert sample_mask logical condition

### DIFF
--- a/orangecontrib/datafusion/movielens.py
+++ b/orangecontrib/datafusion/movielens.py
@@ -100,8 +100,8 @@ def hide_data(table, percentage, sampling_type):
     else:
         raise ValueError("Unknown sampling method.")
 
-    sample_mask, oos_mask = (np.logical_and(rand <  percentage, ~np.isnan(table)),
-                             np.logical_and(rand >= percentage, ~np.isnan(table)))
+    sample_mask, oos_mask = (np.logical_and(rand >= percentage, ~np.isnan(table)),
+                             np.logical_and(rand <  percentage, ~np.isnan(table)))
     return sample_mask, oos_mask
 
 


### PR DESCRIPTION
`sample_mask` is applied as `MaskedArray.mask` and thus _hides_ the data, not exposes it.
